### PR TITLE
Remove ConfigureEnvironment import

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake, tools, ConfigureEnvironment
+from conans import ConanFile, CMake, tools
 import os
 
 


### PR DESCRIPTION
This failed when I tried to make a package on Windows because conan does not seem to have a module called ConfigureEnvironment. Since this module isn't used in the script it should be removed.